### PR TITLE
Extract into classes code for fetching membership lists and ID mappings

### DIFF
--- a/lib/mapping/ep_identifier_to_wikidata.rb
+++ b/lib/mapping/ep_identifier_to_wikidata.rb
@@ -1,0 +1,34 @@
+require 'everypolitician'
+
+module Mapping
+  class EPIdentifierToWikidata
+    def initialize(ep_slug:, ep_id_scheme:)
+      @ep_slug = ep_slug
+      @ep_id_scheme = ep_id_scheme
+    end
+
+    def to_h
+      @to_h = popolo.persons.map { |p| [p.identifier(ep_id_scheme), p.wikidata] }.to_h
+    end
+
+    private
+
+    attr_reader :ep_slug, :ep_id_scheme
+
+    def split_ep_slug
+      ep_slug.split('/')
+    end
+
+    def ep_country_slug
+      split_ep_slug[0]
+    end
+
+    def ep_house_slug
+      split_ep_slug[1]
+    end
+
+    def popolo
+      @popolo ||= Everypolitician::Index.new.country(ep_country_slug).legislature(ep_house_slug).popolo
+    end
+  end
+end

--- a/lib/membership_list/morph.rb
+++ b/lib/membership_list/morph.rb
@@ -1,0 +1,31 @@
+require 'rest-client'
+
+module MembershipList
+  class Morph
+    def initialize(morph_scraper:, morph_sql_query: )
+      @morph_scraper = morph_scraper
+      @morph_sql_query = morph_sql_query
+    end
+
+    def to_a
+      morph_json_data
+    end
+
+    private
+
+    attr_reader :morph_scraper, :morph_sql_query
+
+    def morph_url
+      unless ENV['MORPH_API_KEY']
+        raise 'You must set MORPH_API_KEY in the environment'
+      end
+      @morph_url ||= "https://morph.io/#{morph_scraper}/data.json?key=#{ENV['MORPH_API_KEY']}&query=#{URI.encode_www_form_component(morph_sql_query)}"
+    end
+
+    def morph_json_data
+      @morph_json_data ||= JSON.parse(RestClient.get(morph_url), symbolize_names: true)
+    rescue RestClient::Exception => e
+      raise "Morph query #{morph_sql_query.inspect} failed: #{e.message}"
+    end
+  end
+end

--- a/lib/membership_list/wikidata.rb
+++ b/lib/membership_list/wikidata.rb
@@ -4,8 +4,9 @@ module MembershipList
   class Wikidata
     WIKIDATA_SPARQL_URL = 'https://query.wikidata.org/sparql'.freeze
 
-    def initialize(wikidata_membership_item:)
+    def initialize(wikidata_membership_item:, label_language:)
       @wikidata_membership_item = wikidata_membership_item
+      @label_language = label_language
     end
 
     def to_a
@@ -16,16 +17,16 @@ module MembershipList
 
     private
 
-    attr_reader :wikidata_membership_item
+    attr_reader :wikidata_membership_item, :label_language
 
     def sparql_query
-      @sparql_query ||= """
+      @sparql_query ||= "
         SELECT ?item ?itemLabel
           WHERE {
             ?item wdt:P39 wd:#{wikidata_membership_item}.
-            SERVICE wikibase:label { bd:serviceParam wikibase:language \"[AUTO_LANGUAGE],en\". }
+            SERVICE wikibase:label { bd:serviceParam wikibase:language \"#{label_language}\". }
           }
-"""
+"
     end
 
     def sparql_response

--- a/lib/membership_list/wikidata.rb
+++ b/lib/membership_list/wikidata.rb
@@ -1,0 +1,47 @@
+require 'rest-client'
+
+module MembershipList
+  class Wikidata
+    WIKIDATA_SPARQL_URL = 'https://query.wikidata.org/sparql'.freeze
+
+    def initialize(wikidata_membership_item:)
+      @wikidata_membership_item = wikidata_membership_item
+    end
+
+    def to_a
+      @to_a ||= JSON.parse(
+        sparql_response, symbolize_names: true
+      )[:results][:bindings].map { |r| sparql_result_to_hash(r) }
+    end
+
+    private
+
+    attr_reader :wikidata_membership_item
+
+    def sparql_query
+      @sparql_query ||= """
+        SELECT ?item ?itemLabel
+          WHERE {
+            ?item wdt:P39 wd:#{wikidata_membership_item}.
+            SERVICE wikibase:label { bd:serviceParam wikibase:language \"[AUTO_LANGUAGE],en\". }
+          }
+"""
+    end
+
+    def sparql_response
+      @sparql_response ||= RestClient.get WIKIDATA_SPARQL_URL, params: { query: sparql_query, format: 'json' }
+    rescue RestClient::Exception => e
+      raise "Wikidata query #{query.inspect} failed: #{e.message}"
+    end
+
+    def sparql_result_to_hash(sparql_result)
+      url = sparql_result[:item][:value]
+      item_id = url.split('/').last
+      {
+        item_id: item_id,
+        url: url,
+        name: sparql_result[:itemLabel][:value]
+      }
+    end
+  end
+end

--- a/prompt_prototype.rb
+++ b/prompt_prototype.rb
@@ -27,7 +27,10 @@ morph_list = MembershipList::Morph.new(
 morph_records = morph_list.to_a.map { |d| [d[:id], d] }.to_h
 
 wikidata_list = MembershipList::Wikidata.new(
-  wikidata_membership_item: wikidata_membership_item
+  wikidata_membership_item: wikidata_membership_item,
+  # FIXME: we will probably want to select this based on the country
+  # we're dealing with, but use English labels for the moment
+  label_language: 'en'
 )
 
 wikidata_records = wikidata_list.to_a.map { |h| [h[:item_id], h] }.to_h

--- a/prompt_prototype.rb
+++ b/prompt_prototype.rb
@@ -1,9 +1,9 @@
 require 'bundler/setup'
 require 'json'
-require 'everypolitician'
 
 require_relative 'lib/membership_list/morph'
 require_relative 'lib/membership_list/wikidata'
+require_relative 'lib/mapping/ep_identifier_to_wikidata'
 
 # FIXME: it's a bit awkward having so many positional command line
 # arguments: we might want to make them named options, or for the the
@@ -32,9 +32,9 @@ wikidata_list = MembershipList::Wikidata.new(
 
 wikidata_records = wikidata_list.to_a.map { |h| [h[:item_id], h] }.to_h
 
-country_slug, house_slug = ep_country_and_house.split('/')
-popolo = Everypolitician::Index.new.country(country_slug).legislature(house_slug).popolo
-morph_wikidata_lookup = popolo.persons.map { |p| [p.identifier(ep_id_scheme), p.wikidata] }.to_h
+morph_wikidata_lookup = Mapping::EPIdentifierToWikidata.new(
+  ep_slug: ep_country_and_house, ep_id_scheme: ep_id_scheme
+).to_h
 
 morph_ids_with_wikidata, morph_ids_without_wikidata = morph_records.keys.partition do |morph_id|
   morph_wikidata_lookup[morph_id]


### PR DESCRIPTION
This pull request hopefully separates out the code that (a) goes to remote services (such as a Morph scraper, the Wikidata SPARQL endpoint and EveryPolitician) to generate lists of memberships and ID mappings from (b) the code left in in the `prompt_prototype.rb` script, which takes those and produces a list of discrepancies between the sources.

Hopefully this makes it easier to look at the `prompt_prototype.rb` script to work out what might be the next functionality that could be factored out.

The `MembershipLists` classes return an array of one hash via their `to_a` method, where each hash has properties of a particular membership.

n.b. I haven't added automated tests for this because before doing extra work to do that, I'd quite like feedback on whether this generally looks like a sensible refactoring.